### PR TITLE
feat: expose x,y coordinates of a CurveAffine point

### DIFF
--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -194,6 +194,16 @@ macro_rules! curve_impl {
                 (*self).into()
             }
 
+            fn into_xy_unchecked(&self) -> (Self::Base, Self::Base) {
+                (self.x, self.y)
+            }
+            fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self {
+                Self {
+                    x: x,
+                    y: y,
+                    infinity: false
+                }
+            }
         }
 
         impl Rand for $projective {

--- a/src/bn256/ec.rs
+++ b/src/bn256/ec.rs
@@ -190,6 +190,17 @@ macro_rules! curve_impl {
             fn into_projective(&self) -> $projective {
                 (*self).into()
             }
+
+            fn into_xy_unchecked(&self) -> (Self::Base, Self::Base) {
+                (self.x, self.y)
+            }
+            fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self {
+                Self {
+                    x: x,
+                    y: y,
+                    infinity: false
+                }
+            }
         }
        
         impl CurveProjective for $projective {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub trait Engine: ScalarEngine {
         G2: Into<Self::G2Affine>,
     {
         Self::final_exponentiation(&Self::miller_loop(
-            [(&(p.into().prepare()), &(q.into().prepare()))].into_iter(),
+            [(&(p.into().prepare()), &(q.into().prepare()))].iter(),
         )).unwrap()
     }
 }
@@ -231,6 +231,11 @@ pub trait CurveAffine:
     fn into_uncompressed(&self) -> Self::Uncompressed {
         <Self::Uncompressed as EncodedPoint>::from_affine(*self)
     }
+
+    /// Returns the (x,y) coordinates of the point
+    fn into_xy_unchecked(&self) -> (Self::Base, Self::Base);
+    /// Converts the provided (x,y) coordinates to a `CurveAffine` point
+    fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self;
 }
 
 pub trait RawEncodable: CurveAffine {


### PR DESCRIPTION
This is cherry-picked from: https://github.com/matter-labs/pairing/tree/112eaf8996ea9f321f44b128e621a6bac92ee101
